### PR TITLE
feat: implement Policy as Code for docker

### DIFF
--- a/.github/workflows/quality-and-security.yml
+++ b/.github/workflows/quality-and-security.yml
@@ -67,3 +67,15 @@ jobs:
             - run: npm ci
             - name: Build (production)
               run: npm run build
+    policy-check:
+        name: Policy as Code (Conftest)
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v4
+
+            - name: Run Conftest (OPA)
+              uses: instrumenta/conftest-action@master
+              with:
+                  files: Dockerfile
+                  policy: policy/

--- a/policy/docker.rego
+++ b/policy/docker.rego
@@ -1,0 +1,20 @@
+package main
+
+# prohibiting latest as base image
+deny[msg] {
+  input[i].Cmd == "from"
+  val := split(input[i].Value[0], ":")
+  count(val) > 1
+  val[1] == "latest"
+  msg = sprintf("Não use a tag 'latest' na imagem base: %s", [input[i].Value[0]])
+}
+
+# shouldn´t run as root
+warn[msg] {
+  not has_user_instruction
+  msg = "O Dockerfile idealmente deve especificar um 'USER' para não rodar como root"
+}
+
+has_user_instruction {
+  input[i].Cmd == "user"
+}


### PR DESCRIPTION
This PR introduces Policy as Code to the pipeline using Conftest (Open Policy Agent). It adds a governance layer that automatically validates the Dockerfile against security best practices before the build stage.