### PR TITLE
🔒 [security fix] Validate URLs in SafeUrlPipe

### DIFF
--- a/src/core/common/pipe/safe-url.pipe.spec.ts
+++ b/src/core/common/pipe/safe-url.pipe.spec.ts
@@ -1,5 +1,5 @@
 import { TestBed } from "@angular/core/testing";
-import { DomSanitizer } from "@angular/platform-browser";
+import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
 import { SafeUrlPipe } from "./safe-url.pipe";
 import { environment } from "../../../environments/environment";
 
@@ -28,31 +28,35 @@ describe("SafeUrlPipe", () => {
 
     it("should allow blob URLs", () => {
         const blobUrl = "blob:http://localhost:4200/123-456";
-        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(blobUrl as any);
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(blobUrl as SafeResourceUrl);
 
         const result = pipe.transform(blobUrl);
 
-        expect(result).toBe(blobUrl as any);
+        expect(result).toBe(blobUrl as SafeResourceUrl);
         expect(sanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(blobUrl);
     });
 
     it("should allow URLs from mainServerUrl", () => {
         const trustedUrl = "https://trusted.com/api/data";
-        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(trustedUrl as any);
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(
+            trustedUrl as SafeResourceUrl,
+        );
 
         const result = pipe.transform(trustedUrl);
 
-        expect(result).toBe(trustedUrl as any);
+        expect(result).toBe(trustedUrl as SafeResourceUrl);
         expect(sanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(trustedUrl);
     });
 
     it("should allow URLs from automationServerUrl", () => {
         const trustedUrl = "https://automation.io/dashboard";
-        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(trustedUrl as any);
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(
+            trustedUrl as SafeResourceUrl,
+        );
 
         const result = pipe.transform(trustedUrl);
 
-        expect(result).toBe(trustedUrl as any);
+        expect(result).toBe(trustedUrl as SafeResourceUrl);
         expect(sanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(trustedUrl);
     });
 
@@ -79,6 +83,6 @@ describe("SafeUrlPipe", () => {
 
     it("should handle empty or null input", () => {
         expect(pipe.transform("")).toBe("");
-        expect(pipe.transform(null as any)).toBe("");
+        expect(pipe.transform(null as unknown as string)).toBe("");
     });
 });

--- a/src/core/common/pipe/safe-url.pipe.spec.ts
+++ b/src/core/common/pipe/safe-url.pipe.spec.ts
@@ -1,8 +1,84 @@
+import { TestBed } from "@angular/core/testing";
+import { DomSanitizer } from "@angular/platform-browser";
 import { SafeUrlPipe } from "./safe-url.pipe";
+import { environment } from "../../../environments/environment";
 
 describe("SafeUrlPipe", () => {
+    let pipe: SafeUrlPipe;
+    let sanitizer: jasmine.SpyObj<DomSanitizer>;
+
+    beforeEach(() => {
+        const sanitizerSpy = jasmine.createSpyObj("DomSanitizer", [
+            "bypassSecurityTrustResourceUrl",
+        ]);
+        TestBed.configureTestingModule({
+            providers: [SafeUrlPipe, { provide: DomSanitizer, useValue: sanitizerSpy }],
+        });
+        pipe = TestBed.inject(SafeUrlPipe);
+        sanitizer = TestBed.inject(DomSanitizer) as jasmine.SpyObj<DomSanitizer>;
+
+        // Set up environment for testing
+        environment.mainServerUrl = "trusted.com";
+        environment.automationServerUrl = "automation.io";
+    });
+
     it("create an instance", () => {
-        const pipe = new SafeUrlPipe();
         expect(pipe).toBeTruthy();
+    });
+
+    it("should allow blob URLs", () => {
+        const blobUrl = "blob:http://localhost:4200/123-456";
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(blobUrl as any);
+
+        const result = pipe.transform(blobUrl);
+
+        expect(result).toBe(blobUrl as any);
+        expect(sanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(blobUrl);
+    });
+
+    it("should allow URLs from mainServerUrl", () => {
+        const trustedUrl = "https://trusted.com/api/data";
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(trustedUrl as any);
+
+        const result = pipe.transform(trustedUrl);
+
+        expect(result).toBe(trustedUrl as any);
+        expect(sanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(trustedUrl);
+    });
+
+    it("should allow URLs from automationServerUrl", () => {
+        const trustedUrl = "https://automation.io/dashboard";
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(trustedUrl as any);
+
+        const result = pipe.transform(trustedUrl);
+
+        expect(result).toBe(trustedUrl as any);
+        expect(sanitizer.bypassSecurityTrustResourceUrl).toHaveBeenCalledWith(trustedUrl);
+    });
+
+    it("should block untrusted URLs", () => {
+        const untrustedUrl = "https://malicious.com/attack";
+        spyOn(console, "warn");
+
+        const result = pipe.transform(untrustedUrl);
+
+        expect(result).toBe("");
+        expect(sanitizer.bypassSecurityTrustResourceUrl).not.toHaveBeenCalled();
+        expect(console.warn).toHaveBeenCalled();
+    });
+
+    it("should block javascript: URLs", () => {
+        const dangerousUrl = "javascript:alert('xss')";
+        spyOn(console, "warn");
+
+        const result = pipe.transform(dangerousUrl);
+
+        expect(result).toBe("");
+        expect(sanitizer.bypassSecurityTrustResourceUrl).not.toHaveBeenCalled();
+    });
+
+    it("should handle empty or null input", () => {
+        expect(pipe.transform("")).toBe("");
+        expect(pipe.transform(null as any)).toBe("");
     });
 });

--- a/src/core/common/pipe/safe-url.pipe.spec.ts
+++ b/src/core/common/pipe/safe-url.pipe.spec.ts
@@ -38,9 +38,7 @@ describe("SafeUrlPipe", () => {
 
     it("should allow URLs from mainServerUrl", () => {
         const trustedUrl = "https://trusted.com/api/data";
-        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(
-            trustedUrl as SafeResourceUrl,
-        );
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(trustedUrl as SafeResourceUrl);
 
         const result = pipe.transform(trustedUrl);
 
@@ -50,9 +48,7 @@ describe("SafeUrlPipe", () => {
 
     it("should allow URLs from automationServerUrl", () => {
         const trustedUrl = "https://automation.io/dashboard";
-        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(
-            trustedUrl as SafeResourceUrl,
-        );
+        sanitizer.bypassSecurityTrustResourceUrl.and.returnValue(trustedUrl as SafeResourceUrl);
 
         const result = pipe.transform(trustedUrl);
 

--- a/src/core/common/pipe/safe-url.pipe.ts
+++ b/src/core/common/pipe/safe-url.pipe.ts
@@ -1,5 +1,6 @@
 import { Pipe, PipeTransform, inject } from "@angular/core";
-import { DomSanitizer } from "@angular/platform-browser";
+import { DomSanitizer, SafeResourceUrl } from "@angular/platform-browser";
+import { environment } from "../../../environments/environment";
 
 @Pipe({
     name: "safeUrl",
@@ -8,7 +9,45 @@ import { DomSanitizer } from "@angular/platform-browser";
 export class SafeUrlPipe implements PipeTransform {
     private domSanitizer = inject(DomSanitizer);
 
-    transform(url: string) {
-        return this.domSanitizer.bypassSecurityTrustResourceUrl(url);
+    transform(url: string): SafeResourceUrl | string {
+        if (!url) {
+            return "";
+        }
+
+        if (this.isTrusted(url)) {
+            return this.domSanitizer.bypassSecurityTrustResourceUrl(url);
+        }
+
+        console.warn(`SafeUrlPipe: Blocked untrusted URL: ${url}`);
+        return "";
+    }
+
+    private isTrusted(url: string): boolean {
+        if (url.startsWith("blob:")) {
+            return true;
+        }
+
+        try {
+            const parsedUrl = new URL(url.startsWith("http") ? url : `https://${url}`);
+            const hostname = parsedUrl.hostname.toLowerCase();
+
+            const trustedHosts = [
+                environment.mainServerUrl,
+                environment.automationServerUrl,
+            ].filter(Boolean) as string[];
+
+            return trustedHosts.some(trustedHost => {
+                try {
+                    const trustedParsed = new URL(
+                        trustedHost.startsWith("http") ? trustedHost : `https://${trustedHost}`,
+                    );
+                    return hostname === trustedParsed.hostname.toLowerCase();
+                } catch {
+                    return hostname === trustedHost.toLowerCase();
+                }
+            });
+        } catch {
+            return false;
+        }
     }
 }

--- a/src/core/common/pipe/safe-url.pipe.ts
+++ b/src/core/common/pipe/safe-url.pipe.ts
@@ -36,7 +36,7 @@ export class SafeUrlPipe implements PipeTransform {
                 environment.automationServerUrl,
             ].filter(Boolean) as string[];
 
-            return trustedHosts.some((trustedHost) => {
+            return trustedHosts.some(trustedHost => {
                 try {
                     const trustedParsed = new URL(
                         trustedHost.startsWith("http") ? trustedHost : `https://${trustedHost}`,

--- a/src/core/common/pipe/safe-url.pipe.ts
+++ b/src/core/common/pipe/safe-url.pipe.ts
@@ -36,7 +36,7 @@ export class SafeUrlPipe implements PipeTransform {
                 environment.automationServerUrl,
             ].filter(Boolean) as string[];
 
-            return trustedHosts.some(trustedHost => {
+            return trustedHosts.some((trustedHost) => {
                 try {
                     const trustedParsed = new URL(
                         trustedHost.startsWith("http") ? trustedHost : `https://${trustedHost}`,


### PR DESCRIPTION
🎯 **What:** This PR fixes a security vulnerability in `SafeUrlPipe` where URLs were being marked as safe without any validation.

⚠️ **Risk:** Bypassing security for unvalidated URLs could allow malicious external resources (like those from untrusted domains or using the `javascript:` protocol) to be loaded into the application, potentially leading to Cross-Site Scripting (XSS) or other injection attacks.

🛡️ **Solution:** 
- Implemented an `isTrusted` check within `SafeUrlPipe`.
- URLs are only bypassed if they are `blob:` URLs or if their hostname matches `mainServerUrl` or `automationServerUrl` defined in the environment.
- Untrusted URLs now return an empty string and trigger a warning in the console.
- Added a full set of unit tests in `src/core/common/pipe/safe-url.pipe.spec.ts` to verify the new security logic.


---
*PR created automatically by Jules for task [9222493686249996988](https://jules.google.com/task/9222493686249996988) started by @Rfluid*