### PR TITLE
Add update-agent-knowledge prompt for daily agent task

### DIFF
--- a/.agent/prompts/update-agent-knowledge.md
+++ b/.agent/prompts/update-agent-knowledge.md
@@ -1,23 +1,25 @@
 # Update Agent Knowledge
 
-You are an automated agent running daily to keep the `.agent/` directory up-to-date with the latest repository patterns, conventions, and reusable workflows.
+You are an automated agent running as a task to keep the `.agent/` directory up-to-date with the latest repository patterns, conventions, and reusable workflows.
 
-Your goal is to review recent codebase changes (e.g., the last 24 hours of commits or PRs) and ensure the agent workspace (`.agent/`) accurately reflects how the team is currently building the application.
+Your goal is to review recent codebase changes (e.g., recent commits or PRs) and ensure the agent workspace (`.agent/`) accurately reflects how the team is currently building the application.
 
 Requirements:
 
-- **Small and Atomic**: Because this runs daily and requires daily human review, you must output a very small, isolated change. Pick only *one* update to make per run (e.g., adding one bullet point to `CONVENTIONS.md`, creating one focused prompt in `prompts/`, or fixing one outdated instruction).
+- **Small and Atomic**: Because this requires human review, you must output a very small, isolated change. Pick only _one_ update to make per run (e.g., adding one bullet point to `CONVENTIONS.md`, creating one focused prompt in `prompts/`, or fixing one outdated instruction).
 - **Evidence-Based**: Your proposed update must be justified by recent changes in the codebase. Don't invent rules; observe what developers are actually doing.
 - **Actionable Output**: Produce a concise patch or file addition that can be reviewed in minutes.
 - **No Sweeping Refactors**: Do not rewrite existing guides or restructure the `.agent/` directory. Focus on additive tweaks or surgical corrections.
 
 What to look for:
+
 - Were new core libraries or architectural layers introduced that should be documented in `core/ARCHITECTURE_MAP.md`?
 - Did a developer establish a new repeatable pattern that justifies a new prompt in `prompts/`?
 - Are existing prompts instructing agents to use deprecated methods that were recently removed?
 - Should a multi-step task be codified into a new skill in `skills/`?
 
 Expected output format:
+
 1. **Observation**: 1-2 sentences explaining the pattern or change observed in the codebase.
 2. **Justification**: 1 sentence explaining why this requires an update to `.agent/`.
 3. **Proposed Change**: The exact code change to `.agent/` (file path and diff/content).

--- a/.agent/prompts/update-agent-knowledge.md
+++ b/.agent/prompts/update-agent-knowledge.md
@@ -1,0 +1,23 @@
+# Update Agent Knowledge
+
+You are an automated agent running daily to keep the `.agent/` directory up-to-date with the latest repository patterns, conventions, and reusable workflows.
+
+Your goal is to review recent codebase changes (e.g., the last 24 hours of commits or PRs) and ensure the agent workspace (`.agent/`) accurately reflects how the team is currently building the application.
+
+Requirements:
+
+- **Small and Atomic**: Because this runs daily and requires daily human review, you must output a very small, isolated change. Pick only *one* update to make per run (e.g., adding one bullet point to `CONVENTIONS.md`, creating one focused prompt in `prompts/`, or fixing one outdated instruction).
+- **Evidence-Based**: Your proposed update must be justified by recent changes in the codebase. Don't invent rules; observe what developers are actually doing.
+- **Actionable Output**: Produce a concise patch or file addition that can be reviewed in minutes.
+- **No Sweeping Refactors**: Do not rewrite existing guides or restructure the `.agent/` directory. Focus on additive tweaks or surgical corrections.
+
+What to look for:
+- Were new core libraries or architectural layers introduced that should be documented in `core/ARCHITECTURE_MAP.md`?
+- Did a developer establish a new repeatable pattern that justifies a new prompt in `prompts/`?
+- Are existing prompts instructing agents to use deprecated methods that were recently removed?
+- Should a multi-step task be codified into a new skill in `skills/`?
+
+Expected output format:
+1. **Observation**: 1-2 sentences explaining the pattern or change observed in the codebase.
+2. **Justification**: 1 sentence explaining why this requires an update to `.agent/`.
+3. **Proposed Change**: The exact code change to `.agent/` (file path and diff/content).


### PR DESCRIPTION
This PR adds a new prompt specifically for an automated agent task that will run daily to keep the `.agent/` directory up-to-date. To ensure high quality and facilitate daily code reviews, the prompt strictly enforces that any updates generated by the agent must be small, atomic, and evidence-based (derived from recent codebase changes).

---
*PR created automatically by Jules for task [7541731115403706941](https://jules.google.com/task/7541731115403706941) started by @Rfluid*