### PR TITLE
chore(agent): add O(1) map lookup rule to CONVENTIONS.md

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -26,6 +26,7 @@ Repository-wide implementation rules for `wacraft-client`.
 - Controllers extend `MainServerControllerService` for HTTP concerns.
 - Realtime integrations extend `MainServerGatewayService`.
 - Stores own local arrays, maps, loading flags, and orchestration.
+- Prefer O(1) Map lookups over O(N) array searches for performance, especially in state stores.
 - Workspace changes should clear workspace-scoped state.
 
 ## Multi-Tenancy


### PR DESCRIPTION
1. **Observation**: Recently in commit `e5422b2`, developers refactored the `ConversationStoreService` to replace O(N) array searching with an O(1) Map lookup (`conversationMap`) to optimize performance when managing and retrieving conversations.
2. **Justification**: The `.agent/core/CONVENTIONS.md` document currently does not guide agents to prioritize or look for O(1) Map lookups over O(N) array searches in state stores, even though performance optimization in data structures is a confirmed development pattern.
3. **Proposed Change**: Modified `.agent/core/CONVENTIONS.md` under the "Data Flow" section to add a bullet point instructing agents to prefer O(1) Map lookups for performance optimization in stores.

---
*PR created automatically by Jules for task [10542932792290522423](https://jules.google.com/task/10542932792290522423) started by @Rfluid*