### PR TITLE
🎨 Palette: Improve Accessibility for Icon-only Buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+## 2024-04-09 - Focus State Accessibility
+
+**Learning:** There is a common pattern in the application's common components where buttons (especially icon-only buttons) apply `focus:outline-none` or `outline-none` to remove the default browser focus ring, but fail to provide a fallback focus indicator. This makes keyboard navigation very difficult as users lose track of their active element.
+
+**Action:** Whenever applying `focus:outline-none` or `outline-none` to remove native outlines, ensure an accessible replacement like `focus-visible:ring-2` (often paired with a ring color like `focus-visible:ring-gray-400`) is added so keyboard users still get visual feedback while mouse users don't see distracting rings.

--- a/.agent/prompts/update-agent-knowledge.md
+++ b/.agent/prompts/update-agent-knowledge.md
@@ -1,23 +1,25 @@
 # Update Agent Knowledge
 
-You are an automated agent running daily to keep the `.agent/` directory up-to-date with the latest repository patterns, conventions, and reusable workflows.
+You are an automated agent running as a task to keep the `.agent/` directory up-to-date with the latest repository patterns, conventions, and reusable workflows.
 
-Your goal is to review recent codebase changes (e.g., the last 24 hours of commits or PRs) and ensure the agent workspace (`.agent/`) accurately reflects how the team is currently building the application.
+Your goal is to review recent codebase changes (e.g., recent commits or PRs) and ensure the agent workspace (`.agent/`) accurately reflects how the team is currently building the application.
 
 Requirements:
 
-- **Small and Atomic**: Because this runs daily and requires daily human review, you must output a very small, isolated change. Pick only *one* update to make per run (e.g., adding one bullet point to `CONVENTIONS.md`, creating one focused prompt in `prompts/`, or fixing one outdated instruction).
+- **Small and Atomic**: Because this requires human review, you must output a very small, isolated change. Pick only _one_ update to make per run (e.g., adding one bullet point to `CONVENTIONS.md`, creating one focused prompt in `prompts/`, or fixing one outdated instruction).
 - **Evidence-Based**: Your proposed update must be justified by recent changes in the codebase. Don't invent rules; observe what developers are actually doing.
 - **Actionable Output**: Produce a concise patch or file addition that can be reviewed in minutes.
 - **No Sweeping Refactors**: Do not rewrite existing guides or restructure the `.agent/` directory. Focus on additive tweaks or surgical corrections.
 
 What to look for:
+
 - Were new core libraries or architectural layers introduced that should be documented in `core/ARCHITECTURE_MAP.md`?
 - Did a developer establish a new repeatable pattern that justifies a new prompt in `prompts/`?
 - Are existing prompts instructing agents to use deprecated methods that were recently removed?
 - Should a multi-step task be codified into a new skill in `skills/`?
 
 Expected output format:
+
 1. **Observation**: 1-2 sentences explaining the pattern or change observed in the codebase.
 2. **Justification**: 1 sentence explaining why this requires an update to `.agent/`.
 3. **Proposed Change**: The exact code change to `.agent/` (file path and diff/content).

--- a/.agent/prompts/update-agent-knowledge.md
+++ b/.agent/prompts/update-agent-knowledge.md
@@ -1,0 +1,23 @@
+# Update Agent Knowledge
+
+You are an automated agent running daily to keep the `.agent/` directory up-to-date with the latest repository patterns, conventions, and reusable workflows.
+
+Your goal is to review recent codebase changes (e.g., the last 24 hours of commits or PRs) and ensure the agent workspace (`.agent/`) accurately reflects how the team is currently building the application.
+
+Requirements:
+
+- **Small and Atomic**: Because this runs daily and requires daily human review, you must output a very small, isolated change. Pick only *one* update to make per run (e.g., adding one bullet point to `CONVENTIONS.md`, creating one focused prompt in `prompts/`, or fixing one outdated instruction).
+- **Evidence-Based**: Your proposed update must be justified by recent changes in the codebase. Don't invent rules; observe what developers are actually doing.
+- **Actionable Output**: Produce a concise patch or file addition that can be reviewed in minutes.
+- **No Sweeping Refactors**: Do not rewrite existing guides or restructure the `.agent/` directory. Focus on additive tweaks or surgical corrections.
+
+What to look for:
+- Were new core libraries or architectural layers introduced that should be documented in `core/ARCHITECTURE_MAP.md`?
+- Did a developer establish a new repeatable pattern that justifies a new prompt in `prompts/`?
+- Are existing prompts instructing agents to use deprecated methods that were recently removed?
+- Should a multi-step task be codified into a new skill in `skills/`?
+
+Expected output format:
+1. **Observation**: 1-2 sentences explaining the pattern or change observed in the codebase.
+2. **Justification**: 1 sentence explaining why this requires an update to `.agent/`.
+3. **Proposed Change**: The exact code change to `.agent/` (file path and diff/content).

--- a/src/app/common/copy-button/copy-button.component.html
+++ b/src/app/common/copy-button/copy-button.component.html
@@ -1,10 +1,11 @@
 <button
     type="button"
-    class="flex items-center justify-center rounded text-gray-400 transition-all hover:bg-gray-200 hover:text-gray-600 focus:outline-none dark:hover:bg-gray-700 dark:hover:text-gray-300"
+    class="flex items-center justify-center rounded text-gray-400 transition-all hover:bg-gray-200 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
     [ngClass]="[sizeButtonClass, buttonClass, copied ? copiedTextClass : '']"
     [class.opacity-100]="copied"
     (click)="copy($event)"
     [title]="copied ? 'Copied!' : 'Copy to clipboard'"
+    [attr.aria-label]="copied ? 'Copied to clipboard' : 'Copy to clipboard'"
 >
     <svg
         *ngIf="!copied"

--- a/src/app/common/sidebar/sidebar.component.html
+++ b/src/app/common/sidebar/sidebar.component.html
@@ -10,7 +10,10 @@
     >
         <button
             id="sidebar-toggle"
-            class="flex aspect-square w-10 items-center justify-center rounded-lg border border-gray-500 text-white dark:border-gray-500"
+            class="flex aspect-square w-10 items-center justify-center rounded-lg border border-gray-500 text-white focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-500"
+            [attr.aria-label]="queryParamsService.sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'"
+            [attr.aria-expanded]="queryParamsService.sidebarOpen"
+            [title]="queryParamsService.sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'"
             (click)="
                 queryParamsService.sidebarOpen
                     ? queryParamsService.closeSidebar()

--- a/src/app/common/sidebar/sidebar.component.html
+++ b/src/app/common/sidebar/sidebar.component.html
@@ -11,7 +11,9 @@
         <button
             id="sidebar-toggle"
             class="flex aspect-square w-10 items-center justify-center rounded-lg border border-gray-500 text-white focus-visible:ring-2 focus-visible:ring-gray-400 dark:border-gray-500"
-            [attr.aria-label]="queryParamsService.sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'"
+            [attr.aria-label]="
+                queryParamsService.sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'
+            "
             [attr.aria-expanded]="queryParamsService.sidebarOpen"
             [title]="queryParamsService.sidebarOpen ? 'Collapse sidebar' : 'Expand sidebar'"
             (click)="

--- a/src/app/common/small-button/small-button.component.html
+++ b/src/app/common/small-button/small-button.component.html
@@ -1,6 +1,6 @@
 <button
     [ngClass]="{
-        'flex aspect-square items-center justify-center rounded-full outline-none active:bg-gray-200 dark:active:bg-gray-600': true,
+        'flex aspect-square items-center justify-center rounded-full outline-none focus-visible:ring-2 focus-visible:ring-gray-400 active:bg-gray-200 dark:active:bg-gray-600': true,
         'bg-gray-300 dark:bg-gray-500': active,
         'hover:bg-gray-400 dark:hover:bg-gray-600': !active,
     }"

--- a/src/app/common/timeout-error-modal/timeout-error-modal.component.html
+++ b/src/app/common/timeout-error-modal/timeout-error-modal.component.html
@@ -7,7 +7,12 @@
                 <p class="text-lg font-medium">{{ headerMessage }}</p>
             </div>
             @if (data) {
-                <button (click)="toggleData()" class="rounded">
+                <button
+                    (click)="toggleData()"
+                    class="rounded focus:outline-none focus-visible:ring-2 focus-visible:ring-red-400"
+                    aria-label="Toggle error details"
+                    [attr.aria-expanded]="showData"
+                >
                     @if (!showData) {
                         <i class="fas fa-chevron-down"></i>
                     }


### PR DESCRIPTION
💡 **What:** Added `focus-visible` ring styling to replace hidden outlines (`focus:outline-none`) across several shared UI components (`sidebar`, `copy-button`, `small-button`, and `timeout-error-modal`). Also added missing `aria-label`, `aria-expanded`, and `title` attributes where relevant.
🎯 **Why:** To improve keyboard navigation and discoverability for screen reader users by ensuring icon-only interactive elements are identifiable and have visible focus indicators.
📸 **Before/After:** No major visual layout changes, but keyboard navigation now correctly shows focus rings around icon buttons.
♿ **Accessibility:** Replaced hard-to-see native outlines that were disabled with clear `focus-visible` styling, added missing ARIA labels to describe icon-only button actions.

---
*PR created automatically by Jules for task [4445315626199016329](https://jules.google.com/task/4445315626199016329) started by @Rfluid*