### PR TITLE
🎨 Palette: Add accessibility labels to filter removal buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,0 @@
-## YYYY-MM-DD - [Missing aria-labels for icon-only filter deletion buttons]
-**Learning:** Found that the "delete" icons in the search filter lists across multiple sidebars lacked accessibility labels.
-**Action:** Always add `aria-label` and `i18n-aria-label` to icon-only buttons for screen reader and internationalization support.

--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - [Missing aria-labels for icon-only filter deletion buttons]
+**Learning:** Found that the "delete" icons in the search filter lists across multiple sidebars lacked accessibility labels.
+**Action:** Always add `aria-label` and `i18n-aria-label` to icon-only buttons for screen reader and internationalization support.

--- a/src/app/campaigns/campaigns-sidebar/campaigns-sidebar.component.html
+++ b/src/app/campaigns/campaigns-sidebar/campaigns-sidebar.component.html
@@ -55,6 +55,8 @@
                             <button
                                 class="ml-1 flex aspect-square w-6 items-center justify-center rounded-full hover:bg-blue-600/40"
                                 (click)="campaignStore.removeFilter(filter)"
+                                aria-label="Remove filter"
+                                i18n-aria-label
                             >
                                 <mat-icon class="material-icons-outlined !h-5 !w-5"
                                     >delete</mat-icon

--- a/src/app/chats-sidebar/chats-sidebar.component.html
+++ b/src/app/chats-sidebar/chats-sidebar.component.html
@@ -72,6 +72,8 @@
                             <button
                                 class="ml-1 flex aspect-square w-6 items-center justify-center rounded-full hover:bg-blue-600/40"
                                 (click)="conversationStore.removeFilter(filter)"
+                                aria-label="Remove filter"
+                                i18n-aria-label
                             >
                                 <mat-icon class="material-icons-outlined !h-5 !w-5"
                                     >delete</mat-icon

--- a/src/app/templates/template-sidebar/template-sidebar.component.html
+++ b/src/app/templates/template-sidebar/template-sidebar.component.html
@@ -364,6 +364,8 @@
                             <button
                                 class="ml-1 flex aspect-square w-6 items-center justify-center rounded-full hover:bg-blue-600/40"
                                 (click)="templateStore.removeFilter(filter)"
+                                aria-label="Remove filter"
+                                i18n-aria-label
                             >
                                 <mat-icon class="material-icons-outlined !h-5 !w-5"
                                     >delete</mat-icon

--- a/src/app/users/user-sidebar/user-sidebar.component.html
+++ b/src/app/users/user-sidebar/user-sidebar.component.html
@@ -57,6 +57,8 @@
                             <button
                                 class="ml-1 flex aspect-square w-6 items-center justify-center rounded-full hover:bg-blue-600/40"
                                 (click)="userStore.removeFilter(filter)"
+                                aria-label="Remove filter"
+                                i18n-aria-label
                             >
                                 <mat-icon class="material-icons-outlined !h-5 !w-5"
                                     >delete</mat-icon

--- a/src/app/webhooks/webhook-sidebar/webhook-sidebar.component.html
+++ b/src/app/webhooks/webhook-sidebar/webhook-sidebar.component.html
@@ -57,6 +57,8 @@
                             <button
                                 class="ml-1 flex aspect-square w-6 items-center justify-center rounded-full hover:bg-blue-600/40"
                                 (click)="webhookStore.removeFilter(filter)"
+                                aria-label="Remove filter"
+                                i18n-aria-label
                             >
                                 <mat-icon class="material-icons-outlined !h-5 !w-5"
                                     >delete</mat-icon


### PR DESCRIPTION
🎨 Palette: Add `aria-label` to icon-only filter remove buttons

💡 **What:** Added `aria-label="Remove filter"` (and corresponding Angular i18n attribute) to the `mat-icon` buttons used for removing search filters.

🎯 **Why:** Icon-only interactive elements were invisible to screen readers, meaning visually impaired users could not determine the function of these buttons or clear their applied search filters effectively.

♿ **Accessibility:** Improves WCAG compliance by providing an accessible name for the remove filter actions across all main sidebar navigation views.

---
*PR created automatically by Jules for task [1439303730191525198](https://jules.google.com/task/1439303730191525198) started by @Rfluid*