### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix XSS vulnerability in media previews

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-04-11 - Misuse of Angular's bypassSecurityTrustUrl for Sanitization
+
+**Vulnerability:** Found multiple instances where user-provided URLs for media (images, documents, videos) were passed directly to `this.sanitizer.bypassSecurityTrustUrl(url)`. Developers commented "Sanitize the URL" next to this call.
+**Learning:** `bypassSecurityTrustUrl` does not sanitize the input; it explicitly tells Angular to trust the value and bypass all built-in sanitization. This is a critical security vulnerability leading to XSS if an attacker provides a malicious URL like `javascript:alert(1)`. There is a clear misunderstanding among developers regarding the difference between `sanitizer.sanitize` and `sanitizer.bypassSecurityTrust*`.
+**Prevention:** Always use `this.sanitizer.sanitize(SecurityContext.URL, url)` (or the integer 4 for URL context) when dealing with user-supplied URLs that need to be bound in the template. `bypassSecurityTrust*` should only be used for completely trusted, internal values, or when rigorous custom validation is applied before bypassing.

--- a/src/app/contacts/contact-info/media-preview/media-preview.component.ts
+++ b/src/app/contacts/contact-info/media-preview/media-preview.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, inject } from "@angular/core";
+import { Component, Input, OnInit, SecurityContext, inject } from "@angular/core";
 import { Conversation } from "../../../../core/message/model/conversation.model";
 import { CommonModule } from "@angular/common";
 import { MessageDataPipe } from "../../../../core/message/pipe/message-data.pipe";
@@ -43,7 +43,12 @@ export class MediaPreviewComponent implements OnInit {
         if (!mediaData) return;
         const url = mediaData?.link;
         if (url) {
-            this.mediaSafeUrl = this.sanitizer.bypassSecurityTrustUrl(url); // Sanitize the URL
+            const sanitizedUrl = this.sanitizer.sanitize(SecurityContext.URL, url); // Sanitize the URL
+            if (sanitizedUrl) {
+                this.mediaSafeUrl = sanitizedUrl;
+            } else {
+                this.logger.error("Failed to sanitize the URL for preview");
+            }
             return;
         }
         if (!mediaData.id) return;
@@ -56,8 +61,14 @@ export class MediaPreviewComponent implements OnInit {
 
         const url = mediaData?.link;
         if (url) {
+            const sanitizedUrl = this.sanitizer.sanitize(SecurityContext.URL, url);
+            if (!sanitizedUrl) {
+                this.logger.error("Failed to sanitize the URL for download");
+                return;
+            }
+
             const a = document.createElement("a");
-            a.href = url;
+            a.href = sanitizedUrl;
             a.download = mediaData?.filename || "downloaded_file"; // Optional: set the file name
             a.click();
 

--- a/src/app/messages/message-media-content/message-media-content.component.ts
+++ b/src/app/messages/message-media-content/message-media-content.component.ts
@@ -1,5 +1,13 @@
 import { CommonModule } from "@angular/common";
-import { Component, EventEmitter, Input, OnInit, Output, SecurityContext, inject } from "@angular/core";
+import {
+    Component,
+    EventEmitter,
+    Input,
+    OnInit,
+    Output,
+    SecurityContext,
+    inject,
+} from "@angular/core";
 import { DomSanitizer, SafeUrl } from "@angular/platform-browser";
 import { MessageType, ReceivedMessageType } from "../../../core/message/model/message-type.model";
 import { LocalSettingsService } from "../../local-settings.service";

--- a/src/app/messages/message-media-content/message-media-content.component.ts
+++ b/src/app/messages/message-media-content/message-media-content.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from "@angular/common";
-import { Component, EventEmitter, Input, OnInit, Output, inject } from "@angular/core";
+import { Component, EventEmitter, Input, OnInit, Output, SecurityContext, inject } from "@angular/core";
 import { DomSanitizer, SafeUrl } from "@angular/platform-browser";
 import { MessageType, ReceivedMessageType } from "../../../core/message/model/message-type.model";
 import { LocalSettingsService } from "../../local-settings.service";
@@ -39,7 +39,12 @@ export class MessageMediaContentComponent implements OnInit {
         if (!this.mediaData) return;
         const url = this.mediaData?.link;
         if (url) {
-            this.mediaSafeUrl = this.sanitizer.bypassSecurityTrustUrl(url); // Sanitize the URL
+            const sanitizedUrl = this.sanitizer.sanitize(SecurityContext.URL, url); // Sanitize the URL
+            if (sanitizedUrl) {
+                this.mediaSafeUrl = sanitizedUrl;
+            } else {
+                this.logger.error("Failed to sanitize the URL for preview");
+            }
             return;
         }
         if (!this.mediaData.id) return;
@@ -51,8 +56,14 @@ export class MessageMediaContentComponent implements OnInit {
 
         const url = this.mediaData?.link;
         if (url) {
+            const sanitizedUrl = this.sanitizer.sanitize(SecurityContext.URL, url);
+            if (!sanitizedUrl) {
+                this.logger.error("Failed to sanitize the URL for download");
+                return;
+            }
+
             const a = document.createElement("a");
-            a.href = url;
+            a.href = sanitizedUrl;
             a.download = this.mediaData?.filename || "downloaded_file"; // Optional: set the file name
             a.click();
 


### PR DESCRIPTION
🚨 Severity: CRITICAL

💡 Vulnerability: Found multiple instances where user-provided URLs for media (images, documents, videos) were passed directly to `this.sanitizer.bypassSecurityTrustUrl(url)`. This explicitly bypasses Angular's built-in XSS protection and trusts the value unconditionally.

🎯 Impact: An attacker could send a message with a malicious link (e.g. `javascript:alert(1)`) as a media attachment. When the victim views the chat or clicks download, arbitrary JavaScript executes in the context of their session.

🔧 Fix: Replaced the unsafe `bypassSecurityTrustUrl` calls with `this.sanitizer.sanitize(SecurityContext.URL, url)` in `MediaPreviewComponent` and `MessageMediaContentComponent` to properly enforce URL sanitization rules.

✅ Verification: Code lints successfully and application builds. Tests run but fail with a pre-existing dependency error. Also added a journal entry for Sentinel to record the difference between sanitizing and bypassing security in Angular.

---
*PR created automatically by Jules for task [16708357157475844312](https://jules.google.com/task/16708357157475844312) started by @Rfluid*