### PR TITLE
🎨 Palette: Add ARIA labels to password visibility toggle buttons

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -57,6 +57,7 @@
                 class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none dark:text-slate-500 dark:hover:text-slate-300"
                 (click)="togglePasswordVisibility()"
                 aria-label="Toggle password visibility"
+                i18n-aria-label
             >
                 <span class="material-icons-outlined text-xl">
                     {{ showPassword ? "visibility_off" : "visibility" }}

--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -86,6 +86,8 @@
                     type="button"
                     class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none dark:text-slate-500 dark:hover:text-slate-300"
                     (click)="togglePasswordVisibility()"
+                    aria-label="Toggle password visibility"
+                    i18n-aria-label
                 >
                     <span class="material-icons-outlined text-xl">
                         {{ showPassword ? "visibility_off" : "visibility" }}

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -47,6 +47,8 @@
                     type="button"
                     class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none"
                     (click)="togglePasswordVisibility()"
+                    aria-label="Toggle password visibility"
+                    i18n-aria-label
                 >
                     <span class="material-icons-outlined text-xl">
                         {{ showPassword ? "visibility_off" : "visibility" }}


### PR DESCRIPTION
🎨 Palette: Add ARIA labels to password visibility toggle buttons

💡 What:
Added `aria-label` to the icon-only toggle password visibility buttons on the register and reset-password forms, along with adding `i18n-aria-label` to the button for login, register, and reset-password.

🎯 Why: 
To improve accessibility for users interacting via screen readers, ensuring the purpose of the icon-only password visibility toggle button is clear.

♿ Accessibility: Added `aria-label` providing text alternatives for icon-only buttons.

---
*PR created automatically by Jules for task [8447341353536984975](https://jules.google.com/task/8447341353536984975) started by @Rfluid*