### PR TITLE
docs: add security conventions for sanitizing URLs

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -50,6 +50,10 @@ Repository-wide implementation rules for `wacraft-client`.
 - Preserve placeholders exactly in XLF files.
 - Do not mark purely dynamic values as translatable.
 
+## Security
+
+- Prevent XSS vulnerabilities by using `sanitizer.sanitize(SecurityContext.URL, url)` for user-provided URLs instead of `sanitizer.bypassSecurityTrustUrl()`, which explicitly disables sanitization.
+
 ## Verification
 
 - For scoped code changes, prefer targeted checks first.


### PR DESCRIPTION
1. **Observation**: A recent critical commit (`46ea511`) fixed an XSS vulnerability by replacing the usage of `bypassSecurityTrustUrl()` with `sanitizer.sanitize(SecurityContext.URL, url)` because the former unconditionally disabled angular's security sanitization.
2. **Justification**: This establishes a new security standard for processing URLs and needs to be documented so developers and agents don't reintroduce the vulnerability when handling user-provided URLs.
3. **Proposed Change**: Added a `## Security` section in `.agent/core/CONVENTIONS.md` to document the correct usage of `sanitizer.sanitize` over `bypassSecurityTrustUrl`.

---
*PR created automatically by Jules for task [3861237768693429329](https://jules.google.com/task/3861237768693429329) started by @Rfluid*