### PR TITLE
🎨 Palette: Add focus-visible rings to auth toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+## 2024-04-12 - Missing Focus Indicators on Icon Buttons
+
+**Learning:** Found that inline icon-only buttons (like password visibility toggles) using `focus:outline-none` lack visual feedback for keyboard navigation, creating an accessibility barrier.
+**Action:** Always provide a `focus-visible:ring-2` fallback when hiding default outlines on interactive elements to ensure keyboard users can track focus.

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -54,7 +54,7 @@
             />
             <button
                 type="button"
-                class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none dark:text-slate-500 dark:hover:text-slate-300"
+                class="absolute right-3 top-9 rounded text-slate-400 transition-colors hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 dark:text-slate-500 dark:hover:text-slate-300"
                 (click)="togglePasswordVisibility()"
                 aria-label="Toggle password visibility"
                 i18n-aria-label

--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -84,7 +84,7 @@
                 />
                 <button
                     type="button"
-                    class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none dark:text-slate-500 dark:hover:text-slate-300"
+                    class="absolute right-3 top-9 rounded text-slate-400 transition-colors hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 dark:text-slate-500 dark:hover:text-slate-300"
                     (click)="togglePasswordVisibility()"
                     aria-label="Toggle password visibility"
                     i18n-aria-label

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -45,7 +45,7 @@
                 />
                 <button
                     type="button"
-                    class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none"
+                    class="absolute right-3 top-9 rounded text-slate-400 transition-colors hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
                     (click)="togglePasswordVisibility()"
                     aria-label="Toggle password visibility"
                     i18n-aria-label


### PR DESCRIPTION
💡 **What:** Added `focus-visible:ring-2` to the password visibility toggle icon buttons in the authentication flows (`login`, `register`, `reset-password`). Created a UX journal entry.
🎯 **Why:** Previously, the buttons used `focus:outline-none`, which removed the default focus ring for keyboard users, causing an accessibility barrier for navigation.
📸 **Before/After:** The eye icon now cleanly shows a blue focus ring outline when tabbed to via keyboard.
♿ **Accessibility:** Re-established focus tracking for screen reader/keyboard users.

---
*PR created automatically by Jules for task [12991862612646185076](https://jules.google.com/task/12991862612646185076) started by @Rfluid*