### PR TITLE
docs: update agent conventions for DOM sanitization

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -20,6 +20,10 @@ Repository-wide implementation rules for `wacraft-client`.
 - Follow existing mutable-store patterns before introducing new reactive state
   primitives.
 
+## Security
+
+- Prevent XSS by using Angular's `DomSanitizer.sanitize(SecurityContext.URL, url)` on user-supplied URLs instead of `bypassSecurityTrustUrl()`, or use the `SafeUrlPipe` for safe URL sanitization.
+
 ## Data Flow
 
 - Default flow is `Component -> Store -> Controller -> Backend`.


### PR DESCRIPTION
Updated `.agent/core/CONVENTIONS.md` to include a security rule derived from recent codebase changes addressing an XSS vulnerability, which mandates using `DomSanitizer.sanitize` instead of `bypassSecurityTrustUrl`.

---
*PR created automatically by Jules for task [2565519638347501179](https://jules.google.com/task/2565519638347501179) started by @Rfluid*