### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing Vulnerabilities

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -3,3 +3,9 @@
 **Vulnerability:** Found multiple instances where user-provided URLs for media (images, documents, videos) were passed directly to `this.sanitizer.bypassSecurityTrustUrl(url)`. Developers commented "Sanitize the URL" next to this call.
 **Learning:** `bypassSecurityTrustUrl` does not sanitize the input; it explicitly tells Angular to trust the value and bypass all built-in sanitization. This is a critical security vulnerability leading to XSS if an attacker provides a malicious URL like `javascript:alert(1)`. There is a clear misunderstanding among developers regarding the difference between `sanitizer.sanitize` and `sanitizer.bypassSecurityTrust*`.
 **Prevention:** Always use `this.sanitizer.sanitize(SecurityContext.URL, url)` (or the integer 4 for URL context) when dealing with user-supplied URLs that need to be bound in the template. `bypassSecurityTrust*` should only be used for completely trusted, internal values, or when rigorous custom validation is applied before bypassing.
+
+## 2026-04-13 - Reverse Tabnabbing Vulnerability
+
+**Vulnerability:** Found instances where external URLs, specifically user-supplied ones (e.g., in contact details), were rendered with `target="_blank"` but without `rel="noopener noreferrer"`.
+**Learning:** Opening a new tab using `target="_blank"` without `noopener noreferrer` grants the newly opened page access to the `window.opener` object of the originating tab. An attacker could exploit this by providing a malicious URL that redirects the original tab to a phishing page (reverse tabnabbing), stealing user credentials or sensitive data.
+**Prevention:** Always append the `rel="noopener noreferrer"` attribute to anchor tags (`<a>`) that use `target="_blank"`, especially when the `href` points to external or user-generated URLs.

--- a/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
+++ b/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
@@ -126,6 +126,7 @@
                                                     : 'https://' + url.url
                                             "
                                             target="_blank"
+                                            rel="noopener noreferrer"
                                             class="text-sm"
                                         >
                                             {{ url.url }}

--- a/src/app/messages/message-info/message-info.component.html
+++ b/src/app/messages/message-info/message-info.component.html
@@ -76,6 +76,7 @@
                     <a
                         href="https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#error-codes"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
                         <strong i18n>Code:</strong>&nbsp;
                         <span class="cursor-pointer text-red-600 underline dark:text-red-400">{{


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: Reverse Tabnabbing
Found instances where `target="_blank"` was used on anchor tags without the accompanying `rel="noopener noreferrer"` attribute. Notably, this occurred in the contacts modal where user-supplied URLs were rendered.

🎯 **Impact**: 
When a link lacks `noopener noreferrer`, the destination page gains access to the `window.opener` object of the source page. A malicious user-supplied URL could use this to navigate the original tab to a phishing site, potentially tricking the user into revealing sensitive information.

🔧 **Fix**: 
Added `rel="noopener noreferrer"` to the affected `<a>` tags in `src/app/messages/message-contacts-modal/message-contacts-modal.component.html` and `src/app/messages/message-info/message-info.component.html`.

✅ **Verification**: 
Run tests and verified the fix applied correctly. Evaluated the repository's HTML templates to ensure there were no other obvious instances. The changes are strictly HTML attribute additions and do not affect functional layout or logic.

---
*PR created automatically by Jules for task [15149592910106182831](https://jules.google.com/task/15149592910106182831) started by @Rfluid*