### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel="noopener noreferrer" to external links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -9,3 +9,9 @@
 **Vulnerability:** Found bypassSecurityTrustUrl used on dynamically generated object URLs instead of proper sanitization.
 **Learning:** Generating object URLs from unknown/untrusted Blobs and wrapping them in bypassSecurityTrustUrl can expose applications to XSS attacks since Angular will not sanitize them. Returning them simply as strings sanitized by DomSanitizer.sanitize is cleaner and safer.
 **Prevention:** Avoid bypassSecurityTrustUrl unless there's a verified need and strict custom validation. Use sanitize(SecurityContext.URL, url) and return strings for safe template bindings.
+
+## 2026-04-15 - Missing rel="noopener noreferrer" on External Links
+
+**Vulnerability:** Found multiple instances where `target="_blank"` was used on `<a>` tags for external links without `rel="noopener noreferrer"`.
+**Learning:** Developers often forget to include `rel="noopener noreferrer"` when opening external links in a new tab. This can expose the application to reverse tabnabbing vulnerabilities, where the newly opened page can access the `window.opener` object of the original page and potentially redirect it to a malicious site.
+**Prevention:** Always include `rel="noopener noreferrer"` when using `target="_blank"` on external links, especially when rendering user-supplied URLs or linking to external documentation.

--- a/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
+++ b/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
@@ -126,6 +126,7 @@
                                                     : 'https://' + url.url
                                             "
                                             target="_blank"
+                                            rel="noopener noreferrer"
                                             class="text-sm"
                                         >
                                             {{ url.url }}

--- a/src/app/messages/message-info/message-info.component.html
+++ b/src/app/messages/message-info/message-info.component.html
@@ -76,6 +76,7 @@
                     <a
                         href="https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#error-codes"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
                         <strong i18n>Code:</strong>&nbsp;
                         <span class="cursor-pointer text-red-600 underline dark:text-red-400">{{


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: Missing `rel="noopener noreferrer"` attribute on external links that use `target="_blank"`.
🎯 Impact: "Reverse Tabnabbing", where a newly opened tab can access the original page's `window.opener` object, potentially causing a phishing attack or malicious redirect.
🔧 Fix: Added the necessary `rel="noopener noreferrer"` attribute to the two found locations (`message-contacts-modal.component.html` and `message-info.component.html`).
✅ Verification: Verified fix manually by grep checking for `target="_blank"`. Code has been formatted, built, and passed testing.

---
*PR created automatically by Jules for task [4015732461748097590](https://jules.google.com/task/4015732461748097590) started by @Rfluid*