### PR TITLE
🛡️ Sentinel: [MEDIUM] Add rel='noopener noreferrer' to target='_blank' links

### DIFF
--- a/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
+++ b/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
@@ -126,6 +126,7 @@
                                                     : 'https://' + url.url
                                             "
                                             target="_blank"
+                                            rel="noopener noreferrer"
                                             class="text-sm"
                                         >
                                             {{ url.url }}

--- a/src/app/messages/message-info/message-info.component.html
+++ b/src/app/messages/message-info/message-info.component.html
@@ -76,6 +76,7 @@
                     <a
                         href="https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#error-codes"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
                         <strong i18n>Code:</strong>&nbsp;
                         <span class="cursor-pointer text-red-600 underline dark:text-red-400">{{


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Links opening in new tabs (`target="_blank"`) without `rel="noopener noreferrer"` can expose the original window to reverse tabnabbing, allowing the newly opened page to execute malicious JavaScript in the context of the referring page.
🎯 **Impact:** If a user clicks on a malicious user-supplied URL (e.g., in contact cards) or if an external document gets compromised, an attacker might be able to silently redirect the original application window to a phishing site or perform actions on behalf of the user.
🔧 **Fix:** Added `rel="noopener noreferrer"` to all `<a>` tags utilizing `target="_blank"` within `message-contacts-modal.component.html` and `message-info.component.html`.
✅ **Verification:** Verified by checking that the anchor tags now include the correct `rel` attributes. Ran `npm run test` and `npm run lint` to ensure no functionality is broken.

---
*PR created automatically by Jules for task [4416284295651316973](https://jules.google.com/task/4416284295651316973) started by @Rfluid*