### PR TITLE
⚡ Bolt: Use primitive tracking in message loops to prevent re-renders

### DIFF
--- a/src/app/contacts/contact-info/contact-info.component.html
+++ b/src/app/contacts/contact-info/contact-info.component.html
@@ -206,7 +206,7 @@
             <div
                 class="hide-scrollbar w-full max-w-full space-x-2 overflow-x-scroll whitespace-nowrap pl-2"
             >
-                @for (message of media; track message) {
+                @for (message of media; track message.id) {
                     <app-media-preview
                         class="inline-block w-40"
                         [message]="message"

--- a/src/app/conversations/conversation-body/conversation-body.component.html
+++ b/src/app/conversations/conversation-body/conversation-body.component.html
@@ -14,7 +14,7 @@
 
     @for (
         message of userConversationStore.unsentMessages.get(messagingProductContact.id) || [];
-        track message
+        track message.id
     ) {
         <li
             class="message-container"
@@ -47,7 +47,7 @@
 
     @for (
         message of userConversationStore.messageHistory.get(messagingProductContact.id) || [];
-        track message
+        track message.id
     ) {
         <li
             class="message-container"

--- a/src/core/message/store/user-conversations-store.service.ts
+++ b/src/core/message/store/user-conversations-store.service.ts
@@ -9,7 +9,7 @@ import { MessagingProductContactFromMessagePipe } from "../pipe/messaging-produc
 import { LocalSettingsService } from "../../../app/local-settings.service";
 import { SenderData } from "../model/sender-data.model";
 import { Subject } from "rxjs";
-import { NIL as NilUUID } from "uuid";
+import { NIL as NilUUID, v4 as uuidv4 } from "uuid";
 import { StatusGatewayService } from "../../status/gateway/status-gateway.service";
 import { Status } from "../../status/entity/status.entity";
 import { statusOrder } from "../../status/constant/status-order.constant";
@@ -251,7 +251,7 @@ export class UserConversationsStoreService {
 
         const unsentMessages = this.unsentMessages.get(messagingProductContactId) || [];
         const conversation = {
-            id: "",
+            id: uuidv4(),
             sender_data: senderData,
             to_id: messagingProductContactId,
             from_id: NilUUID,


### PR DESCRIPTION
💡 **What**: Changed Angular `@for` loops rendering message lists to track elements by `message.id` rather than the `message` object reference itself. Added unique UUID generation for locally created unsent messages so they do not collide with an empty string ID.

🎯 **Why**: Using object reference in Angular 17+ tracking causes the framework to re-render the entire list (or parts of it) if the reference to the collection or its objects changes, even if the underlying data is identical. Tracking by a unique primitive identifier prevents this bottleneck. Additionally, unsent messages needed a distinct ID to prevent duplicate tracking key errors.

📊 **Impact**: Reduces unnecessary DOM node destruction and creation. Expected improvement in render times and memory usage for large conversation histories or when frequently appending unsent messages.

🔬 **Measurement**: Inspect Angular DevTools profiler before and after sending a message in a large thread. The number of component instances created and destroyed should drop significantly.

---
*PR created automatically by Jules for task [16325429492539120886](https://jules.google.com/task/16325429492539120886) started by @Rfluid*