### PR TITLE
chore: update agent conventions to require i18n-aria-label

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -49,6 +49,7 @@ Repository-wide implementation rules for `wacraft-client`.
 - Extract strings with `ng extract-i18n --output-path src/locale`.
 - Preserve placeholders exactly in XLF files.
 - Do not mark purely dynamic values as translatable.
+- When adding `aria-label` attributes to elements in templates, always include `i18n-aria-label` to ensure the accessibility text can be translated.
 
 ## Verification
 


### PR DESCRIPTION
1. **Observation**: The codebase frequently uses the `i18n-aria-label` attribute alongside `aria-label` in Angular HTML templates.
2. **Justification**: Ensuring accessibility labels are translatable is a standard pattern in the project that should be explicitly codified for automated workflows.
3. **Proposed Change**: Updated `.agent/core/CONVENTIONS.md` to include a rule under `## i18n` requiring the use of `i18n-aria-label` when adding `aria-label` attributes.

---
*PR created automatically by Jules for task [6213681379890373585](https://jules.google.com/task/6213681379890373585) started by @Rfluid*