### PR TITLE
🛡️ Sentinel: [HIGH] Fix reverse tabnabbing vulnerability in external links

### DIFF
--- a/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
+++ b/src/app/messages/message-contacts-modal/message-contacts-modal.component.html
@@ -126,6 +126,7 @@
                                                     : 'https://' + url.url
                                             "
                                             target="_blank"
+                                            rel="noopener noreferrer"
                                             class="text-sm"
                                         >
                                             {{ url.url }}

--- a/src/app/messages/message-info/message-info.component.html
+++ b/src/app/messages/message-info/message-info.component.html
@@ -76,6 +76,7 @@
                     <a
                         href="https://developers.facebook.com/docs/whatsapp/cloud-api/support/error-codes/#error-codes"
                         target="_blank"
+                        rel="noopener noreferrer"
                     >
                         <strong i18n>Code:</strong>&nbsp;
                         <span class="cursor-pointer text-red-600 underline dark:text-red-400">{{


### PR DESCRIPTION
Added `rel="noopener noreferrer"` to `target="_blank"` anchor tags rendering user URLs to prevent reverse tabnabbing attacks, where a newly opened page could access the original page's `window.opener` object.

Modified files:
- `src/app/messages/message-contacts-modal/message-contacts-modal.component.html`
- `src/app/messages/message-info/message-info.component.html`

---
*PR created automatically by Jules for task [14917058197991599258](https://jules.google.com/task/14917058197991599258) started by @Rfluid*