### PR TITLE
🎨 Palette: Improve accessibility of Copy Button

### DIFF
--- a/src/app/common/copy-button/copy-button.component.html
+++ b/src/app/common/copy-button/copy-button.component.html
@@ -1,10 +1,11 @@
 <button
     type="button"
-    class="flex items-center justify-center rounded text-gray-400 transition-all hover:bg-gray-200 hover:text-gray-600 focus:outline-none dark:hover:bg-gray-700 dark:hover:text-gray-300"
+    class="flex items-center justify-center rounded text-gray-400 transition-all hover:bg-gray-200 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-gray-400 dark:hover:bg-gray-700 dark:hover:text-gray-300"
     [ngClass]="[sizeButtonClass, buttonClass, copied ? copiedTextClass : '']"
     [class.opacity-100]="copied"
     (click)="copy($event)"
     [title]="copied ? 'Copied!' : 'Copy to clipboard'"
+    [attr.aria-label]="copied ? 'Copied' : 'Copy to clipboard'"
 >
     <svg
         *ngIf="!copied"


### PR DESCRIPTION
💡 What: Added accessible focus rings and dynamic `aria-label` attributes to `app-copy-button`.
🎯 Why: The component used `focus:outline-none` without an accessible fallback, hindering keyboard users. Furthermore, as an icon-only button, it lacked screen reader context.
♿ Accessibility: Ensures full keyboard accessibility and screen-reader compatibility for users relying on assistive technologies.

---
*PR created automatically by Jules for task [10925314146804327850](https://jules.google.com/task/10925314146804327850) started by @Rfluid*