### PR TITLE
docs: add accessibility rule to agent conventions

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -51,6 +51,11 @@ Repository-wide implementation rules for `wacraft-client`.
 - Do not mark purely dynamic values as translatable.
 - When adding `aria-label` attributes to elements in templates, always include `i18n-aria-label` to ensure the accessibility text can be translated.
 
+## Accessibility
+
+- When hiding native focus rings on interactive elements (e.g., using Tailwind's `focus:outline-none`), always provide an accessible fallback for keyboard navigation, such as `focus-visible:ring-2`.
+- Always ensure icon-only interactive elements have proper `aria-label` attributes.
+
 ## Verification
 
 - For scoped code changes, prefer targeted checks first.


### PR DESCRIPTION
1. **Observation**: Recent commits (e.g., `0c7af06` and `36d16c0`) established a consistent pattern of replacing native focus rings with accessible Tailwind fallbacks (`focus-visible:ring-2`) and adding `aria-label` to icon-only buttons for screen readers.
2. **Justification**: This pattern needs to be documented in `.agent/core/CONVENTIONS.md` so that future automated implementation tasks and UI changes conform to the established accessibility standards.
3. **Proposed Change**: Added an "Accessibility" section to `.agent/core/CONVENTIONS.md` documenting the focus state fallback and `aria-label` requirements.

---
*PR created automatically by Jules for task [6137664996274870670](https://jules.google.com/task/6137664996274870670) started by @Rfluid*