### PR TITLE
⚡ Bolt: Replace expensive array flatten with efficient loop for status updates

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2024-04-20 - Expensive Array Flattening on Large Maps
+
+**Learning:** Found a performance bottleneck where `[...map.values()].flat().find(...)` was used to search for a specific item across all arrays stored in a Map. This creates a full copy of the arrays, flattens them, and then searches, resulting in massive temporary memory allocation and O(N) performance hit on every status update event, which blocks the main thread in a busy chat app.
+**Action:** Replace `[...map.values()].flat().find(...)` with a `for...of` loop over `map.values()` and use `.find()` on each sub-array, breaking early once found. This avoids large temporary memory allocations and makes the search much faster.

--- a/src/core/message/store/user-conversations-store.service.ts
+++ b/src/core/message/store/user-conversations-store.service.ts
@@ -62,9 +62,13 @@ export class UserConversationsStoreService {
             this.statusGateway.opened,
             this.statusGateway.watchNewStatus((data: Status) => {
                 const messageId = data.message_id;
-                const message = [...this.messageHistory.values()] // get all arrays
-                    .flat() // flatten into a single array
-                    .find(item => item.id === messageId); // find by messageId
+
+                let message: Conversation | undefined;
+                for (const conversations of this.messageHistory.values()) {
+                    message = conversations.find(item => item.id === messageId);
+                    if (message) break;
+                }
+
                 if (!message) return;
 
                 if (!message.statuses) message.statuses = [];


### PR DESCRIPTION
💡 What: Replaced the O(N) array allocation, flatten, and find operation in `watchNewStatus` with an early-exit `for...of` loop.
🎯 Why: Flattening an entire map of arrays into a new array just to find a single message causes massive memory allocation overhead and blocks the main thread in a busy client.
📊 Impact: Expected to reduce memory footprint during chat loading/updates drastically, preventing memory GC stalls and ensuring the main thread stays responsive.
🔬 Measurement: Profile the JS heap size and main thread CPU usage while receiving a large burst of Webhooks for message statuses.

---
*PR created automatically by Jules for task [12216711269581277084](https://jules.google.com/task/12216711269581277084) started by @Rfluid*