### PR TITLE
⚡ Bolt: optimize message history search with early exit loop

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2025-04-21 - Avoid Array Spread and Flattening on Large Maps
+
+**Learning:** Using `.flat()` or array spread operators `[...iterable]` on large data structures like Maps to search for elements causes massive temporary memory allocation overhead and creates an O(N) operation just to structure the data for a search.
+**Action:** Replace `[...map.values()].flat().find(...)` with `for...of` loops iterating through values and using early exits (`break` or `return`) once the element is found. This avoids intermediate object allocation and significantly boosts performance on large datasets.

--- a/src/core/message/store/user-conversations-store.service.ts
+++ b/src/core/message/store/user-conversations-store.service.ts
@@ -62,9 +62,15 @@ export class UserConversationsStoreService {
             this.statusGateway.opened,
             this.statusGateway.watchNewStatus((data: Status) => {
                 const messageId = data.message_id;
-                const message = [...this.messageHistory.values()] // get all arrays
-                    .flat() // flatten into a single array
-                    .find(item => item.id === messageId); // find by messageId
+
+                // ⚡ Bolt: Replaced [...map.values()].flat().find() with a nested for...of loop
+                // to avoid O(N) memory allocation and allow early exit, improving performance on large histories.
+                let message: Conversation | undefined;
+                for (const conversations of this.messageHistory.values()) {
+                    message = conversations.find(item => item.id === messageId);
+                    if (message) break;
+                }
+
                 if (!message) return;
 
                 if (!message.statuses) message.statuses = [];


### PR DESCRIPTION
**💡 What:** Replaced a spread-and-flatten array search (`[...this.messageHistory.values()].flat().find(...)`) with a nested `for...of` loop in `UserConversationsStoreService`.
**🎯 Why:** The previous implementation caused unnecessary memory allocation (O(N) to flatten the Map) and forced a full iteration up to the match, creating a performance bottleneck when searching large message histories.
**📊 Impact:** Eliminates memory overhead from temporary arrays and reduces search time via an early loop exit, yielding faster status updates.
**🔬 Measurement:** Performance can be measured by profiling memory allocation and CPU usage while updating the status of messages in a dense conversation history.

---
*PR created automatically by Jules for task [12128447919855612426](https://jules.google.com/task/12128447919855612426) started by @Rfluid*