### PR TITLE
⚡ Bolt: [performance improvement] optimize Map array flattening

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+## 2026-04-22 - Avoid Array Spreading and Flattening on Large Map Data Structures
+
+**Learning:** Using `[...map.values()].flat().find()` on a `Map` where values are large arrays causes massive temporary memory allocation overhead because it creates a new single giant array with every item, blocking the main thread during execution.
+**Action:** When searching for an element within a `Map` of arrays, use `for...of` loops to iterate through values and `break` early. This maintains O(1) space complexity and minimizes search time by exiting as soon as the element is found.

--- a/src/core/message/store/user-conversations-store.service.ts
+++ b/src/core/message/store/user-conversations-store.service.ts
@@ -62,9 +62,14 @@ export class UserConversationsStoreService {
             this.statusGateway.opened,
             this.statusGateway.watchNewStatus((data: Status) => {
                 const messageId = data.message_id;
-                const message = [...this.messageHistory.values()] // get all arrays
-                    .flat() // flatten into a single array
-                    .find(item => item.id === messageId); // find by messageId
+                let message: Conversation | undefined;
+                // Performance optimization: Avoid .flat() and array spreading on Map which allocates memory proportional to map size
+                // Instead use early exit with for...of loops
+                for (const conversationArray of this.messageHistory.values()) {
+                    message = conversationArray.find(item => item.id === messageId);
+                    if (message) break;
+                }
+
                 if (!message) return;
 
                 if (!message.statuses) message.statuses = [];


### PR DESCRIPTION
💡 **What:** Replaced the array flattening logic `[...this.messageHistory.values()].flat().find(...)` with a nested `for...of` loop and early exit in `UserConversationsStoreService.watchNewStatus`.

🎯 **Why:** Using `.flat()` on an array constructed from `Map.values()` where the values are large arrays creates a massive single array temporarily. This allocates memory proportional to the map size and array lengths, blocking the main thread. A simple loop with an early exit avoids this entirely.

📊 **Impact:** Reduces memory allocation overhead from O(N) to O(1) and decreases average search execution time significantly by exiting the search as soon as the element is found.

🔬 **Measurement:** You can profile memory usage and execution time of the `watchNewStatus` callback when receiving high volumes of status updates for large conversation histories. Memory spikes during status updates should be drastically reduced.

---
*PR created automatically by Jules for task [16231634751179831605](https://jules.google.com/task/16231634751179831605) started by @Rfluid*