### PR TITLE
chore: update agent knowledge on angular for-loop tracking

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -19,6 +19,7 @@ Repository-wide implementation rules for `wacraft-client`.
 - Use `inject()` for dependency wiring when that matches surrounding code.
 - Follow existing mutable-store patterns before introducing new reactive state
   primitives.
+- In Angular 17+ `@for` loops, always track list items by a unique primitive identifier (e.g., `track item.id`) rather than object reference. Use `uuidv4()` for unsaved entities.
 
 ## Data Flow
 


### PR DESCRIPTION
1. Observation: Recent commits (e.g., 5b22e4e7) replaced object reference tracking with primitive ID tracking (`track message.id`) in Angular `@for` loops and used `uuidv4()` for temporary entities to optimize rendering and prevent collisions.
2. Justification: Agents should be aware of this performance optimization and data modeling requirement to apply it consistently in future Angular template modifications.
3. Proposed Change: Added a convention to `.agent/core/CONVENTIONS.md` under 'Angular Patterns' specifying the use of primitive tracking in `@for` loops and `uuidv4()` for unsaved entities.

---
*PR created automatically by Jules for task [9148686517425244592](https://jules.google.com/task/9148686517425244592) started by @Rfluid*