### PR TITLE
⚡ Bolt: Use primitive tracking in @for loops for conversations list

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -2,3 +2,8 @@
 
 **Learning:** Found a critical performance bottleneck where the codebase was using `[...map.values()].flat().find(...)` to search for items within a nested structure on every incoming websocket status update. This approach forces massive array allocations and iterates through the entire dataset multiple times, wasting memory and CPU cycles.
 **Action:** Always replace `[...iterable].flat().find()` patterns with an early-exiting `for...of` loop over the iterable, which avoids intermediate array creations and reduces the time complexity overhead from O(N) allocations to O(1) space with an O(K) early exit.
+
+## 2024-05-24 - Track by object reference in Angular @for loop
+
+**Learning:** In Angular 17+ @for loops, tracking by object reference instead of a unique primitive identifier can cause unnecessary DOM updates and re-rendering if the object instance changes, even if the underlying data is identical.
+**Action:** Always track list items by a unique primitive identifier (e.g., track item.id) rather than object reference to avoid re-evaluating the DOM on every Angular change detection cycle.

--- a/src/app/conversations/conversations.component.html
+++ b/src/app/conversations/conversations.component.html
@@ -1,5 +1,5 @@
 <div class="h-screen w-full dark:bg-gray-800">
-    @for (params of messagingProductContacts; track params) {
+    @for (params of messagingProductContacts; track params.id) {
         <app-conversation
             [ngClass]="{ hidden: currentMessagingProductContactId !== params.id }"
             [messagingProductContact]="params"


### PR DESCRIPTION
**💡 What:**
Replaced `@for (params of messagingProductContacts; track params)` with `@for (params of messagingProductContacts; track params.id)` in `src/app/conversations/conversations.component.html`.

**🎯 Why:**
Tracking by the object reference itself means Angular will tear down and recreate DOM elements if the array is ever re-assigned with new object instances, even if the underlying data hasn't changed. Tracking by a unique primitive (`track params.id`) ensures elements are properly reused.

**📊 Impact:**
This eliminates unnecessary DOM updates and re-rendering when the `messagingProductContacts` collection is updated with objects that contain the same identity structure, improving the scrolling and update performance in the conversations list.

**🔬 Measurement:**
Check the performance tab when the messages/conversations list receives a real-time update. Without the `.id`, the DOM nodes inside the list will flash green indicating a full re-render, whereas with `track params.id` the nodes remain stable.

---
*PR created automatically by Jules for task [1078743229030366330](https://jules.google.com/task/1078743229030366330) started by @Rfluid*