### PR TITLE
🎨 Palette: [Accessibility] Add aria-labels to icon-only buttons in template builder

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -2,3 +2,8 @@
 
 **Learning:** When using utility classes like `focus:outline-none` on interactive elements, it's critical to ensure that keyboard focus is still accessible by adding a fallback indicator like `focus-visible:ring-2`. Additionally, form inputs must provide a matching `id` corresponding to the `for` attribute in the associated label to ensure compatibility with screen readers and focus functionalities.
 **Action:** Always provide an accessible fallback for keyboard navigation, such as `focus-visible:ring-2` (often paired with a color like `focus-visible:ring-blue-500/50`) when removing standard focus outlines. Additionally, always explicitly include an `id` on inputs referenced by a `for` attribute from a `<label>`.
+
+## 2026-04-25 - Accessible Icon-only Buttons
+
+**Learning:** When using components like `<mat-icon>` within a `<button>`, relying solely on tooltips (e.g., `matTooltip`) is insufficient for accessibility. Icon-only buttons without text content need explicitly defined aria-labels so screen readers can interpret their functionality. Furthermore, using empty `type=""` attributes breaks standard HTML validation and could lead to implicit form submissions.
+**Action:** Always provide explicit `aria-label` attributes on icon-only interactive elements and include `i18n-aria-label` for internationalization. Ensure interactive elements use correct HTML types (e.g., `type="button"`).

--- a/src/app/templates/template-message-builder/template-message-builder.component.html
+++ b/src/app/templates/template-message-builder/template-message-builder.component.html
@@ -104,9 +104,11 @@
                 ></app-copy-button>
 
                 <button
-                    type=""
+                    type="button"
                     matTooltip="Send template to users"
                     i18n-matTooltip
+                    aria-label="Send template to users"
+                    i18n-aria-label
                     (click)="openModal()"
                     class="template-action"
                 >
@@ -115,9 +117,11 @@
                     >
                 </button>
                 <button
-                    type=""
+                    type="button"
                     matTooltip="Download CSV data to fill and add messages to campaign"
                     i18n-matTooltip
+                    aria-label="Download CSV data"
+                    i18n-aria-label
                     (click)="downloadCsvData()"
                     class="template-action"
                 >


### PR DESCRIPTION
💡 **What**: Added `aria-label` and `i18n-aria-label` to the "Send template to users" and "Download CSV data" icon-only buttons in the template message builder component. Also corrected their `type=""` attribute to `type="button"`.
🎯 **Why**: Icon-only buttons relying solely on `matTooltip` are insufficient for screen readers. Explicit `aria-label`s ensure that users relying on assistive technologies can understand the button's purpose. Additionally, an empty `type=""` attribute is invalid HTML and defaults to a "submit" behavior, which could cause accidental form submissions or page reloads.
📸 **Before/After**: No visual changes.
♿ **Accessibility**: Enhanced screen reader support for icon-only template builder actions by providing translatable, explicit ARIA labels.

---
*PR created automatically by Jules for task [8618251367634855803](https://jules.google.com/task/8618251367634855803) started by @Rfluid*