### PR TITLE
🎨 Palette: Add focus states to password toggle buttons

### DIFF
--- a/src/app/register/register.component.html
+++ b/src/app/register/register.component.html
@@ -84,7 +84,7 @@
                 />
                 <button
                     type="button"
-                    class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none dark:text-slate-500 dark:hover:text-slate-300"
+                    class="absolute right-3 top-9 rounded text-slate-400 transition-colors hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 dark:text-slate-500 dark:hover:text-slate-300"
                     (click)="togglePasswordVisibility()"
                     aria-label="Toggle password visibility"
                     i18n-aria-label

--- a/src/app/reset-password/reset-password.component.html
+++ b/src/app/reset-password/reset-password.component.html
@@ -45,7 +45,7 @@
                 />
                 <button
                     type="button"
-                    class="absolute right-3 top-9 text-slate-400 transition-colors hover:text-slate-600 focus:outline-none"
+                    class="absolute right-3 top-9 rounded text-slate-400 transition-colors hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50"
                     (click)="togglePasswordVisibility()"
                     aria-label="Toggle password visibility"
                     i18n-aria-label

--- a/src/app/users/user-details/user-details.component.html
+++ b/src/app/users/user-details/user-details.component.html
@@ -84,7 +84,7 @@
                                 />
                                 <button
                                     type="button"
-                                    class="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 dark:hover:bg-gray-600 dark:hover:text-gray-200"
+                                    class="absolute right-2 top-1/2 -translate-y-1/2 rounded-md p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500/50 dark:hover:bg-gray-600 dark:hover:text-gray-200"
                                     (click)="togglePasswordVisibility()"
                                     aria-label="Toggle password visibility"
                                 >


### PR DESCRIPTION
### 💡 What:
Added visual focus rings (`focus-visible:ring-2`) to the password visibility toggle buttons across the `register`, `reset-password`, and `user-details` components.

### 🎯 Why:
The existing implementation used Tailwind's `focus:outline-none` class which completely stripped the native focus ring from the buttons. This made it impossible for keyboard users navigating via the `Tab` key to know when the button was focused. 

### ♿ Accessibility:
This change significantly improves keyboard accessibility by providing an explicit visual fallback indicator (`focus-visible:ring-blue-500/50`) when the focus outline is disabled. This aligns with accessibility best practices for interactive elements.

### 📸 Before/After:
Before: `Tab` key focus completely hid the toggle button outline, leaving users unaware of their current position.
After: The toggle button now presents a clear, blue focus ring when focused via keyboard navigation.

---
*PR created automatically by Jules for task [16606316248141874482](https://jules.google.com/task/16606316248141874482) started by @Rfluid*