### PR TITLE
chore: update agent conventions for angular @for loop tracking

### DIFF
--- a/.agent/core/CONVENTIONS.md
+++ b/.agent/core/CONVENTIONS.md
@@ -19,6 +19,7 @@ Repository-wide implementation rules for `wacraft-client`.
 - Use `inject()` for dependency wiring when that matches surrounding code.
 - Follow existing mutable-store patterns before introducing new reactive state
   primitives.
+- In `@for` loops, always track list items by a unique primitive identifier (e.g., `track item.id`) rather than object reference to optimize rendering diffs. When tracking unsaved or temporary entities, assign a unique identifier (e.g., `uuidv4()`) instead of an empty string to prevent rendering collisions.
 
 ## Data Flow
 


### PR DESCRIPTION
1. **Observation**: Recent commit `5b22e4e` ("perf(ui): track messages by id instead of object reference") demonstrated a pattern of optimizing Angular 17+ `@for` loops by tracking items via unique primitive identifiers (`track item.id`) instead of object references (`track item`) and assigning `uuidv4()` to unsent entities instead of empty strings.
2. **Justification**: Updating the agent's core conventions to reflect this ensures future automated tasks adopt this optimal pattern, preventing unnecessary DOM recreation and avoiding rendering collisions for temporary entities.
3. **Proposed Change**: Added a bullet point under the "Angular Patterns" section in `.agent/core/CONVENTIONS.md` explicitly instructing the use of primitive identifier tracking in `@for` loops and generating unique IDs for unsaved entities.

---
*PR created automatically by Jules for task [6576302537241326427](https://jules.google.com/task/6576302537241326427) started by @Rfluid*