### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing rel noopener noreferrer on user-supplied template URLs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -15,3 +15,9 @@
 **Vulnerability:** Found multiple instances where `target="_blank"` was used on `<a>` tags for external links without `rel="noopener noreferrer"`.
 **Learning:** Developers often forget to include `rel="noopener noreferrer"` when opening external links in a new tab. This can expose the application to reverse tabnabbing vulnerabilities, where the newly opened page can access the `window.opener` object of the original page and potentially redirect it to a malicious site.
 **Prevention:** Always include `rel="noopener noreferrer"` when using `target="_blank"` on external links, especially when rendering user-supplied URLs or linking to external documentation.
+
+## 2026-04-27 - Missing target="\_blank" and rel="noopener noreferrer" on External Links from User Data
+
+**Vulnerability:** Found an instance in `message-template-content.component.html` where an external, user-supplied URL (`button.url` from a template message) was rendered in an `<a>` tag without `target="_blank"` and `rel="noopener noreferrer"`.
+**Learning:** When dealing with dynamic, potentially untrusted URLs in templates (e.g., from WhatsApp template buttons), failing to include `target="_blank"` forces the user to navigate away from the current application tab, which is bad UX and a potential security risk if the URL is malicious. Furthermore, not pairing it with `rel="noopener noreferrer"` exposes the application to reverse tabnabbing.
+**Prevention:** Always ensure that external links, especially those populated from user data, open in a new tab securely by explicitly including both `target="_blank"` and `rel="noopener noreferrer"`.

--- a/src/app/messages/message-template-content/message-template-content.component.html
+++ b/src/app/messages/message-template-content/message-template-content.component.html
@@ -79,6 +79,8 @@
                         @if (button.url) {
                             <a
                                 href="{{ button.url }}"
+                                target="_blank"
+                                rel="noopener noreferrer"
                                 class="flex h-full w-full items-center justify-center"
                             >
                                 <i class="fa-solid fa-arrow-up-right-from-square mr-1"></i>


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: User-supplied URL (`button.url` from a template message) was rendered in an `<a>` tag without `target="_blank"` and `rel="noopener noreferrer"`.
🎯 Impact: Forces the user to navigate away from the current application tab which is bad UX and potentially malicious. Not pairing it with `rel="noopener noreferrer"` exposes the application to reverse tabnabbing.
🔧 Fix: Add `target="_blank"` and `rel="noopener noreferrer"` to the `a` tag `href="{{ button.url }}"`. Added a log to `.jules/sentinel.md` with the critical learning.
✅ Verification: Tested using formatting, linting, and building, verified there are no new lock files or unintended modifications.

---
*PR created automatically by Jules for task [4232027624333186655](https://jules.google.com/task/4232027624333186655) started by @Rfluid*