### PR TITLE
chore(.agent): add preflight checks to prevent duplicate agentic PRs

### DIFF
--- a/.agent/prompts/implement-change.md
+++ b/.agent/prompts/implement-change.md
@@ -2,6 +2,18 @@
 
 Implement a scoped change in `wacraft-client`.
 
+Preflight (run before opening any PR):
+
+- `git fetch origin develop` and `git diff origin/develop -- <target paths>`.
+  If the pattern you intended to fix is already gone from `develop`, abandon
+  the change and don't open a PR.
+- `grep -F '<key phrase from your learning>' .jules/<role>.md` (e.g.
+  `bolt.md`, `palette.md`, `sentinel.md`). If a learning entry covering the
+  same theme already exists, do not duplicate it — extend at most.
+- For doc-only changes to `.agent/core/CONVENTIONS.md`, grep the file for
+  the exact rule text first. If a substantively equivalent line already
+  exists, abandon the change.
+
 Requirements:
 
 - Trace the current behavior before editing.

--- a/.agent/prompts/update-agent-knowledge.md
+++ b/.agent/prompts/update-agent-knowledge.md
@@ -12,8 +12,7 @@ Preflight (run before proposing any change):
 - `grep -F '<key phrase>' .agent/core/CONVENTIONS.md` (and the target file
   if different) for the rule text you plan to add. If a substantively
   equivalent line already exists, do not open a PR.
-- For `.jules/<role>.md` learning entries, `grep -F '<key phrase>'
-  .jules/<role>.md` first. If covered, do not add a duplicate entry.
+- For `.jules/<role>.md` learning entries, `grep -F '<key phrase>' .jules/<role>.md` first. If covered, do not add a duplicate entry.
 
 Requirements:
 

--- a/.agent/prompts/update-agent-knowledge.md
+++ b/.agent/prompts/update-agent-knowledge.md
@@ -4,6 +4,17 @@ You are an automated agent running as a task to keep the `.agent/` directory up-
 
 Your goal is to review recent codebase changes (e.g., recent commits or PRs) and ensure the agent workspace (`.agent/`) accurately reflects how the team is currently building the application.
 
+Preflight (run before proposing any change):
+
+- `git fetch origin develop` and re-read the file you intend to edit at
+  `origin/develop`. Don't trust your local copy — agents have been
+  duplicating rules that already landed.
+- `grep -F '<key phrase>' .agent/core/CONVENTIONS.md` (and the target file
+  if different) for the rule text you plan to add. If a substantively
+  equivalent line already exists, do not open a PR.
+- For `.jules/<role>.md` learning entries, `grep -F '<key phrase>'
+  .jules/<role>.md` first. If covered, do not add a duplicate entry.
+
 Requirements:
 
 - **Small and Atomic**: Because this requires human review, you must output a very small, isolated change. Pick only _one_ update to make per run (e.g., adding one bullet point to `CONVENTIONS.md`, creating one focused prompt in `prompts/`, or fixing one outdated instruction).


### PR DESCRIPTION
Closes #296.

## Summary
- Adds a **Preflight** section to `prompts/implement-change.md` requiring agents to `git diff origin/develop` against the target paths and grep `.jules/<role>.md` for existing learnings before opening a PR.
- Adds a **Preflight** section to `prompts/update-agent-knowledge.md` requiring agents to grep `CONVENTIONS.md` and the target `.jules/<role>.md` for the exact rule text before proposing a docs change.

## Why
The May 7 PR triage found 14 open PRs with heavy duplication:
- 5 Bolt PRs (#261/#262/#264/#267/#269) all rewriting the same `watchNewStatus` Map lookup
- 5 Palette PRs (#239/#256/#257/#263/#266) all touching `copy-button.component.html` with overlapping focus-visible/aria-label edits — #263 was a literal no-op against develop
- 2 Sentinel PRs (#238/#259) duplicating XSS / `noopener` guidance after the fixes had already merged
- #265 added an `@for` tracking rule one line below an existing identical line

The agents weren't reading the `.jules/*.md` learning logs that already covered the same theme, and weren't checking whether `develop` had already moved past the pattern they were trying to fix.

## Test plan
- [x] `prompts/implement-change.md` and `prompts/update-agent-knowledge.md` render fine in markdown
- [ ] Confirm the next agentic run that hits these prompts performs the grep / diff steps before opening a PR
- [ ] Re-run a previously-duplicated workflow (e.g. another Bolt pass over `user-conversations-store.service.ts`) and verify it short-circuits instead of opening a duplicate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)