### PR TITLE
perf(user-conversations-store): drop remaining flat()/spread Map searches

### DIFF
--- a/src/core/message/store/user-conversations-store.service.ts
+++ b/src/core/message/store/user-conversations-store.service.ts
@@ -68,20 +68,13 @@ export class UserConversationsStoreService {
                 const messageId = data.message_id;
                 const statusReceivedAt = performance.now();
 
-                // ⚡ Bolt Performance Optimization:
-                // Using for...of instead of [...this.messageHistory.values()].flat().find(...)
-                // Avoids massive array allocations on every status update and allows early exit
-                let message: Conversation | undefined;
+                let message = this.findMessageById(this.messageHistory, messageId);
                 let foundIn: "history" | "unsent" | undefined;
-                for (const [source, conversations] of [
-                    ["history", [...this.messageHistory.values()].flat()] as const,
-                    ["unsent", [...this.unsentMessages.values()].flat()] as const,
-                ]) {
-                    message = conversations.find(item => item.id === messageId);
-                    if (message) {
-                        foundIn = source;
-                        break;
-                    }
+                if (message) {
+                    foundIn = "history";
+                } else {
+                    message = this.findMessageById(this.unsentMessages, messageId);
+                    if (message) foundIn = "unsent";
                 }
 
                 if (!message) {
@@ -233,6 +226,18 @@ export class UserConversationsStoreService {
         await this.unsentMutex.release(messagingProductContactId);
     }
 
+    private findMessageById(
+        map: Map<string, Conversation[]>,
+        id: string,
+    ): Conversation | undefined {
+        for (const list of map.values()) {
+            for (const item of list) {
+                if (item.id === id) return item;
+            }
+        }
+        return undefined;
+    }
+
     private offsetMu = new MutexSwapper<string>();
     async appendConversationIfAtBottom(
         conversation: Conversation,
@@ -359,9 +364,8 @@ export class UserConversationsStoreService {
                 // while the entry was still pending (WS beat HTTP, or a WS for another message
                 // incorrectly evicted our fake entry via fallback). If so, the entry in
                 // unsentMessages is now a stale duplicate with the real id — remove it.
-                const alreadyInHistory = [...this.messageHistory.values()].some(list =>
-                    list.some(m => m.id === realId),
-                );
+                const alreadyInHistory =
+                    this.findMessageById(this.messageHistory, realId) !== undefined;
                 if (alreadyInHistory) {
                     await this.unsentMutex.acquire(messagingProductContactId);
                     const list = this.unsentMessages.get(messagingProductContactId);


### PR DESCRIPTION
Closes #294.

## Summary
- Extract a private `findMessageById(map, id)` helper that walks `Map<string, Conversation[]>` values with nested for-of loops and early-returns on the first hit. Zero allocations.
- Replace the three remaining `[...map.values()].flat()` / `.some(...)` call sites in `user-conversations-store.service.ts` with calls to the helper.

## Why
The May 7 partial refactor of `watchNewStatus` introduced a `for...of` outer loop but kept allocating arrays inside it:

```ts
for (const [source, conversations] of [
    ["history", [...this.messageHistory.values()].flat()] as const,
    ["unsent", [...this.unsentMessages.values()].flat()] as const,
]) { ... }
```

Every inbound `Status` event allocated two arrays sized proportional to total history. The `alreadyInHistory` check in `addUnsent` had the same shape with `.some(list => list.some(...))`.

The Performance section of `.agent/core/CONVENTIONS.md` explicitly forbids this pattern.

## Test plan
- [x] Type-check / Prettier / ESLint clean on the modified file
- [ ] CI: Code Quality (Lint & Prettier) green
- [ ] CI: Production Build Validation green
- [ ] Manual: send a campaign blast, watch DevTools Performance — Minor GC spikes during status floods should disappear
- [ ] Manual: send-then-receive flow still hits the `alreadyInHistory` cleanup path correctly (verify via the `[msg-timing] HTTP resolved … cleaned up stale unsent entry` log line)

🤖 Generated with [Claude Code](https://claude.com/claude-code)